### PR TITLE
Implements PasswordEncoderInterface::needsRehash()

### DIFF
--- a/Services/DrupalPasswordEncoder.php
+++ b/Services/DrupalPasswordEncoder.php
@@ -45,4 +45,12 @@ class DrupalPasswordEncoder implements PasswordEncoderInterface
     {
         return $this->drupalPasswordService->check($raw, $encoded);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function needsRehash(string $encoded): bool
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
It will permit to migrate passwords with version 4.4: https://symfony.com/doc/4.4/security/password_migration.html